### PR TITLE
Add the ability to sort questions on the homepage

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1,7 +1,22 @@
 class SiteController < ApplicationController
 
   def index
-    @questions = Question.all
+    @sorting = params[:sort]
+    case @sorting
+    when "trending"
+      @questions = Question.trending
+    when "open"
+      @questions = Question.open
+    when "recent"
+      @questions = Question.recently_active
+    when "closed"
+      @questions = Question.closed
+    when "unanswered"
+      @questions = Question.unanswered
+    else
+      @questions = Question.trending
+    end
   end
 
 end
+

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -28,7 +28,7 @@ class Question < ActiveRecord::Base
   # getting answer count makes this n+1 right now. 
   # need to figure out how to eager load the answers
   def self.trending
-    Question.select("questions.id, questions.title, questions.user_id, questions.updated_at, count(answers.id) AS answers_count").
+    Question.select("questions.id, questions.title, questions.content, questions.user_id, questions.updated_at, count(answers.id) AS answers_count").
     includes(:user).
     joins(:answers).
     where(:"answers.updated_at" => (Time.now - 90.hours)..Time.now).

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -1,6 +1,6 @@
 <header id="header" class="index-no-box">
     <section class="container clearfix">
-      <div class="logo"><a href="index.html"><img alt="PC LOAD LETTER" src="/img/logo.png"></a></div>
+      <div class="logo"><a href="<%= root_url %>"><img alt="PC LOAD LETTER" src="/img/logo.png"></a></div>
       <nav class="navigation">
         <ul>
           <li class="current_page_item"><a href="<%= root_url %>">Home</a></li>

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -1,9 +1,16 @@
+
+
+
 <section class="container main-content">
 <div class="row">
 <div class="col-md-12">
 <div class="tabs-warp question-tab">
   <ul class="tabs">
-    <li class="tab"><a href="#" class="current">All Questions</a></li>
+    <li class="tab"><a href="?sort=trending" <%= 'class=current' if @sorting =="trending" || @sorting.nil? %>>Trending</a></li>
+    <li class="tab"><a href="?sort=recent" <%= 'class=current' if @sorting =="recent" %>>Recent activity</a></li>
+    <li class="tab"><a href="?sort=unanswered" <%= 'class=current' if @sorting =="unanswered" %>>Without answers</a></li>
+    <li class="tab"><a href="?sort=open" <%= 'class=current' if @sorting =="open" %>>Open</a></li>
+    <li class="tab"><a href="?sort=closed" <%= 'class=current' if @sorting =="closed" %>>Solved</a></li>
   </ul>
 </div>
 <%= render partial: 'questions/indexshow', collection: @questions, as: :question %>


### PR DESCRIPTION
This adjusts the views to take advantage of @walsh9 's new models for sorting the questions. The menu css control is a touch hacky and something I want to experiment with in future releases. I also tidied up some hard coded linkes to use rails path helpers. 

I think there may be a better way to handle all of this. However for now it works.
